### PR TITLE
Workaround for gtk::TreeListModel reversing order of items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "fclones-gui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byte-unit",
  "chrono",

--- a/fclones-gui/Cargo.toml
+++ b/fclones-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fclones-gui"
-version = "0.1.2"
+version = "0.1.3"
 description = "Interactive duplicate file remover"
 authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 homepage = "https://github.com/pkolaczk/fclones-gui"


### PR DESCRIPTION
Workaround for:
https://gitlab.gnome.org/GNOME/gtk/-/issues/5707
https://gitlab.gnome.org/GNOME/gtk/-/issues/5920